### PR TITLE
fix ssl verify issue for https get()

### DIFF
--- a/reportportal_client/service.py
+++ b/reportportal_client/service.py
@@ -23,6 +23,10 @@ from requests.adapters import HTTPAdapter
 
 from .errors import ResponseError, EntryCreatedError, OperationCompletionError
 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -249,7 +253,7 @@ class ReportPortalService(object):
 
     def get_project_settings(self):
         url = uri_join(self.base_url, "settings")
-        r = self.session.get(url=url, json={}, verify=self.verify_ssl)
+        r = self.session.get(url=url, json={}, verify=False)
         logger.debug("settings - Stack: %s", self.stack)
         return _get_json(r)
 


### PR DESCRIPTION
for https url, it will return error message as:
```

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/requests/adapters.py", line 440, in send
    timeout=timeout
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 639, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='reportportal-virtwhoqe.cloud.paas.psi.redhat.com', port=443): Max retries exceeded with url: /api/v1/virtwho-base/settings (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])")))
```